### PR TITLE
Workflow ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,4 +58,4 @@ workflows:
             - test
           filters:
             branches:
-              only: workflowCi
+              only: master


### PR DESCRIPTION
I've tried to re-distribute the bits of the commands into relevant workflow steps

Worth noting I didn't fully understand what the typescript steps were trying to do, and there are no tests in place at the moment so there's just placeholders..

We'll need to prove that this does what is expected, my main concern is that each step in the workflow pulls a fresh docker image to work in, and I don't know if our 'workspace' persists across those images.. If it does, I don't really understand why we would want to '-checkout' for every step.. If it doesn't then we presumably need to do the npm install before running the tests, and we may need to do the type-script part as part of the publish? Not sure..
