### PR TITLE
Update executeRequest configuration method to accept params

### DIFF
--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -69,34 +69,47 @@ export class Configuration {
   // TODO: We need to check it with the other endpoints and improve dependently from situation.
   /**
    * Make an Axios request based on default configuration
-   * @param {object} data
-   * @param {object} schema
-   * @param {any} requestMethodConfiguration
-   * @param {string} url
-   * @param {boolean} checkSignature
+   * @param {object} options
+   * @param {object=} options.data
+   * @param {object=} options.params
+   * @param {object} options.schema
+   * @param {any} options.defaultRequest
+   * @param {url} options.url
+   * @param {boolean=} options.checkSignature
    */
-  executeRequest(
-    data: object,
+  executeRequest({
+    data,
+    params,
+    schema,
+    defaultRequest,
+    url,
+    checkSignature = true,
+  }: {
+    data?: object,
+    params?: object,
     schema: object,
-    requestMethodConfiguration: any,
+    defaultRequest: any,
     url: string,
-    checkSignature: boolean = true,
-  ): AxiosPromise {
+    checkSignature?: boolean,
+  }): AxiosPromise {
+    const payload: any = defaultRequest.method.toLowerCase() === 'get' ? params : data;
+
     try {
-      this.validation(schema, data);
+      this.validation(schema, payload);
     } catch (e) {
       return Promise.reject(e);
     }
 
     const request = {
-      ...requestMethodConfiguration,
+      ...defaultRequest,
       data,
+      params,
       url,
     };
 
     if (checkSignature) {
       request.headers['X-API-Signature'] =
-        this.checkSignature(data, Configuration.accessKeys.privateKey);
+        this.checkSignature(payload, Configuration.accessKeys.privateKey);
     }
 
     return Requester.execute(request);

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,7 +1,7 @@
 /**
  * Import required classes / libraries / constants
  */
-import { AxiosPromise } from 'axios';
+import axios, { AxiosPromise } from 'axios';
 import { Requester } from '../utils/requester';
 import { Configuration } from './configuration';
 import { HttpEndpoints } from './constants/httpEndpoints';
@@ -116,12 +116,12 @@ export class User extends Configuration {
   }
 
   validate(data: UserValidate): AxiosPromise {
-    return this.executeRequest(
+    return this.executeRequest({
       data,
-      userValidateSchema,
-      postConfiguration,
-      Configuration.accessKeys.apiUrl + HttpEndpoints.USER_VALIDATE,
-      false,
-    );
+      schema: userValidateSchema,
+      defaultRequest: postConfiguration,
+      url: Configuration.accessKeys.apiUrl + HttpEndpoints.USER_VALIDATE,
+      checkSignature: false,
+    });
   }
 }

--- a/src/tests/unit/user.spec.ts
+++ b/src/tests/unit/user.spec.ts
@@ -134,22 +134,22 @@ describe('User Class', () => {
   });
 
   describe('Validate method', () => {
-    beforeEach(() => {
-      jest.spyOn(user, 'executeRequest').mockImplementation(() => Promise.resolve());
-    });
-
     it('should successfully call with valid data', () => {
       const data = { username: 'Bob' };
 
+      jest.spyOn(user, 'executeRequest').mockImplementation(
+        () => Promise.resolve()
+      );
+
       user.validate(data);
 
-      expect(user.executeRequest).toHaveBeenCalledWith(
+      expect(user.executeRequest).toHaveBeenCalledWith({
         data,
-        userValidateSchema,
-        postConfiguration,
-        'http://localhost:8080'+ HttpEndpoints.USER_VALIDATE,
-        false,
-      );
+        schema: userValidateSchema,
+        defaultRequest: postConfiguration,
+        url: 'http://localhost:8080' + HttpEndpoints.USER_VALIDATE,
+        checkSignature: false,
+      });
     });
   });
 });


### PR DESCRIPTION
Update executeRequest configuration method to accept params so that requests with queries can be made.

Also:
+ Change the exectueRequest method parameters to be a single options object as the list was getting long
+ Validate `params` when the request method is GET

This builds on top of #69.