### PR TITLE
feat/#163730228-create-access-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,6 @@ Creates a connection invitation for a user to create a relationship with another
 | Name  | Description | Type | Required |
 | ------------- | ------------- | ------------- | ------------- |
 | targetUserId  | The Contact User Identifier. | UUID  | Required  |
-| accessKey  | The Access Key. | String  | Required  |
 | walletId  | The Wallet Identifier. | UUID  | Required  |
 
 **Expected Output**
@@ -402,7 +401,6 @@ Accepts a connection invitation from another user.
 | ------------- | ------------- | ------------- | ------------- |
 | targetUserId  | The Contact User Identifier. | UUID  | Required  |
 | walletId  | The Wallet Identifier. | UUID  | Required  |
-| sourceUserAccessKey  | Source User Access Key. | String  | Required  |
 | targetUserAccessKey  | Target User Access Key. | String  | Required  |
 
 **Expected Output**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/pillarwallet-nodejs-sdk",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "The Node.js SDK, making it easy to interact with the Pillar API.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/interfaces/connections/accept.ts
+++ b/src/lib/interfaces/connections/accept.ts
@@ -22,6 +22,5 @@ SOFTWARE.
 interface ConnectionAccept {
   targetUserId: string;
   walletId: string;
-  sourceUserAccessKey: string;
   targetUserAccessKey: string;
 }

--- a/src/lib/interfaces/connections/accept.ts
+++ b/src/lib/interfaces/connections/accept.ts
@@ -22,5 +22,6 @@ SOFTWARE.
 interface ConnectionAccept {
   targetUserId: string;
   walletId: string;
+  sourceUserAccessKey?: string;
   targetUserAccessKey: string;
 }

--- a/src/lib/interfaces/connections/invite.ts
+++ b/src/lib/interfaces/connections/invite.ts
@@ -21,6 +21,5 @@ SOFTWARE.
 */
 interface ConnectionInvite {
   targetUserId: string;
-  accessKey: string;
   walletId: string;
 }

--- a/src/lib/interfaces/connections/invite.ts
+++ b/src/lib/interfaces/connections/invite.ts
@@ -21,5 +21,6 @@ SOFTWARE.
 */
 interface ConnectionInvite {
   targetUserId: string;
+  accessKey?: string;
   walletId: string;
 }

--- a/src/schemas/connection/accept.json
+++ b/src/schemas/connection/accept.json
@@ -8,10 +8,6 @@
       "description": "The target user ID",
       "type": "string"
     },
-    "sourceUserAccessKey": {
-      "description": "The source user shared access key",
-      "type": "string"
-    },
     "targetUserAccessKey": {
       "description": "The target user shared access key",
       "type": "string"
@@ -21,5 +17,5 @@
       "type": "string"
     }
   },
-  "required": [ "targetUserId", "sourceUserAccessKey", "targetUserAccessKey", "walletId" ]
+  "required": [ "targetUserId", "targetUserAccessKey", "walletId" ]
 }

--- a/src/schemas/connection/accept.json
+++ b/src/schemas/connection/accept.json
@@ -8,6 +8,10 @@
       "description": "The target user ID",
       "type": "string"
     },
+    "sourceUserAccessKey": {
+      "description": "The source user shared access key",
+      "type": "string"
+    },
     "targetUserAccessKey": {
       "description": "The target user shared access key",
       "type": "string"

--- a/src/schemas/connection/invite.json
+++ b/src/schemas/connection/invite.json
@@ -8,14 +8,10 @@
       "description": "The target user ID",
       "type": "string"
     },
-    "accessKey": {
-      "description": "The shared access key",
-      "type": "string"
-    },
     "walletId": {
       "description": "The wallet ID",
       "type": "string"
     }
   },
-  "required": [ "targetUserId", "accessKey", "walletId" ]
+  "required": [ "targetUserId", "walletId" ]
 }

--- a/src/schemas/connection/invite.json
+++ b/src/schemas/connection/invite.json
@@ -8,6 +8,10 @@
       "description": "The target user ID",
       "type": "string"
     },
+    "accessKey": {
+      "description": "The shared access key",
+      "type": "string"
+    },
     "walletId": {
       "description": "The wallet ID",
       "type": "string"

--- a/src/tests/integration/connection.spec.ts
+++ b/src/tests/integration/connection.spec.ts
@@ -42,7 +42,6 @@ describe('Connection Class', () => {
   it('.invite', () => {
     const inputParams = {
       targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-      accessKey: 'abc123',
       walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
     };
 
@@ -61,7 +60,6 @@ describe('Connection Class', () => {
     const inputParams = {
       targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
       walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-      sourceUserAccessKey: 'hello',
       targetUserAccessKey: 'hello',
     };
 

--- a/src/tests/unit/connection.spec.ts
+++ b/src/tests/unit/connection.spec.ts
@@ -58,7 +58,6 @@ describe('Connection Class', () => {
     it('should successfully call with valid data', () => {
       const connectionInviteData = {
         targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-        accessKey: 'abc123',
         walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
       };
 
@@ -80,7 +79,6 @@ describe('Connection Class', () => {
         Configuration.setAuthTokens(accessToken, '');
         const connectionInviteData = {
           targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-          accessKey: 'abc123',
           walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
         };
 
@@ -104,7 +102,6 @@ describe('Connection Class', () => {
       const connectionAcceptData = {
         targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
         walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-        sourceUserAccessKey: 'hello',
         targetUserAccessKey: 'hello',
       };
 
@@ -127,7 +124,6 @@ describe('Connection Class', () => {
         const connectionAcceptData = {
           targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
           walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-          sourceUserAccessKey: 'hello',
           targetUserAccessKey: 'hello',
         };
 


### PR DESCRIPTION
- Support creation of accessKey (on invite) and sourceUserAccessKey (on accept) on backend side
- Support accessKey and sourceUserAccessKey in request payloads for older version

* Make accessKey optional in connection invite request body
* Update tests to reflect the changes on connection invite
* Make sourceUserAccessKey optional on connection accept request body
* Update tests to reflect the changes on connection accept