### PR TITLE
#163730228-create-access-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,6 @@ Creates a connection invitation for a user to create a relationship with another
 | Name  | Description | Type | Required |
 | ------------- | ------------- | ------------- | ------------- |
 | targetUserId  | The Contact User Identifier. | UUID  | Required  |
-| accessKey  | The Access Key. | String  | Required  |
 | walletId  | The Wallet Identifier. | UUID  | Required  |
 
 **Expected Output**
@@ -402,7 +401,6 @@ Accepts a connection invitation from another user.
 | ------------- | ------------- | ------------- | ------------- |
 | targetUserId  | The Contact User Identifier. | UUID  | Required  |
 | walletId  | The Wallet Identifier. | UUID  | Required  |
-| sourceUserAccessKey  | Source User Access Key. | String  | Required  |
 | targetUserAccessKey  | Target User Access Key. | String  | Required  |
 
 **Expected Output**

--- a/src/lib/interfaces/connections/accept.ts
+++ b/src/lib/interfaces/connections/accept.ts
@@ -22,6 +22,6 @@ SOFTWARE.
 interface ConnectionAccept {
   targetUserId: string;
   walletId: string;
-  sourceUserAccessKey: string;
+  sourceUserAccessKey?: string;
   targetUserAccessKey: string;
 }

--- a/src/lib/interfaces/connections/invite.ts
+++ b/src/lib/interfaces/connections/invite.ts
@@ -21,6 +21,6 @@ SOFTWARE.
 */
 interface ConnectionInvite {
   targetUserId: string;
-  accessKey: string;
+  accessKey?: string;
   walletId: string;
 }

--- a/src/schemas/connection/accept.json
+++ b/src/schemas/connection/accept.json
@@ -21,5 +21,5 @@
       "type": "string"
     }
   },
-  "required": [ "targetUserId", "sourceUserAccessKey", "targetUserAccessKey", "walletId" ]
+  "required": [ "targetUserId", "targetUserAccessKey", "walletId" ]
 }

--- a/src/schemas/connection/invite.json
+++ b/src/schemas/connection/invite.json
@@ -17,5 +17,5 @@
       "type": "string"
     }
   },
-  "required": [ "targetUserId", "accessKey", "walletId" ]
+  "required": [ "targetUserId", "walletId" ]
 }

--- a/src/tests/integration/connection.spec.ts
+++ b/src/tests/integration/connection.spec.ts
@@ -42,7 +42,6 @@ describe('Connection Class', () => {
   it('.invite', () => {
     const inputParams = {
       targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-      accessKey: 'abc123',
       walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
     };
 
@@ -61,7 +60,6 @@ describe('Connection Class', () => {
     const inputParams = {
       targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
       walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-      sourceUserAccessKey: 'hello',
       targetUserAccessKey: 'hello',
     };
 

--- a/src/tests/unit/connection.spec.ts
+++ b/src/tests/unit/connection.spec.ts
@@ -58,7 +58,6 @@ describe('Connection Class', () => {
     it('should successfully call with valid data', () => {
       const connectionInviteData = {
         targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-        accessKey: 'abc123',
         walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
       };
 
@@ -80,7 +79,6 @@ describe('Connection Class', () => {
         Configuration.setAuthTokens(accessToken, '');
         const connectionInviteData = {
           targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-          accessKey: 'abc123',
           walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
         };
 
@@ -104,7 +102,6 @@ describe('Connection Class', () => {
       const connectionAcceptData = {
         targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
         walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-        sourceUserAccessKey: 'hello',
         targetUserAccessKey: 'hello',
       };
 
@@ -127,7 +124,6 @@ describe('Connection Class', () => {
         const connectionAcceptData = {
           targetUserId: '6e081b82-dbed-4485-bdbc-a808ad911758',
           walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-          sourceUserAccessKey: 'hello',
           targetUserAccessKey: 'hello',
         };
 


### PR DESCRIPTION
- Make accessKey optional on connection invite (created on backend if not provided in request payload)
- Make sourceUserAccessKey optional on connection accept (created on backend if not provided in request payload)

Reference to platform-core: https://github.com/pillarwallet/platform-core/pull/229