### PR TITLE
Make targetUserAccessKey optional

### DIFF
--- a/src/lib/interfaces/connections/updateIdentityKeys.ts
+++ b/src/lib/interfaces/connections/updateIdentityKeys.ts
@@ -21,7 +21,7 @@ interface ConnectionUpdateIdentityKeys {
   connections: [
     {
       sourceUserAccessKey: string;
-      targetUserAccessKey: string;
+      targetUserAccessKey?: string;
       sourceIdentityKey: string;
       targetIdentityKey: string;
       targetUserId: string;

--- a/src/tests/integration/connection/connectionUpdateIdentityKeys.spec.ts
+++ b/src/tests/integration/connection/connectionUpdateIdentityKeys.spec.ts
@@ -71,7 +71,7 @@ describe('Connection Update Identity Keys', () => {
       targetUserAccessKey: 'target-access-key',
       sourceIdentityKey: 'abc',
       targetIdentityKey: 'xyz',
-      status: 'pending',
+      status: 'accepted',
       updated: true,
     },
   ];
@@ -199,7 +199,7 @@ describe('Connection Update Identity Keys', () => {
     }
   });
 
-  it('expects to return a result when connection status is pending', async () => {
+  it('expects to return a result when connection status is accepted', async () => {
     const inputParams = {
       walletId: sourceUserWalletId,
       connections: [
@@ -227,7 +227,7 @@ describe('Connection Update Identity Keys', () => {
         targetUserAccessKey: expect.any(String),
         sourceIdentityKey: expect.any(String),
         targetIdentityKey: expect.any(String),
-        status: 'pending',
+        status: 'accepted',
         updated: true,
       },
     ]);


### PR DESCRIPTION
Make targetUserAccessKey optional for pending/cancelled/rejected connection updates