### PR TITLE
Add support for the Network header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/pillarwallet-nodejs-sdk",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pillarwallet/pillarwallet-nodejs-sdk",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "The Node.js SDK, making it easy to interact with the Pillar API.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -200,7 +200,7 @@ export class Configuration {
     }
 
     if (Configuration.accessKeys.network) {
-      request.header['Network'] = Configuration.accessKeys.network;
+      request.headers['Network'] = Configuration.accessKeys.network;
     }
 
     if (auth) {

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -40,6 +40,7 @@ export class Configuration {
     notificationsUrl: '',
     investmentsUrl: '',
     username: undefined,
+    network: undefined,
   };
 
   constructor() {
@@ -79,6 +80,16 @@ export class Configuration {
   setUsername(incomingUsername: string) {
     Configuration.accessKeys.username = incomingUsername;
     return incomingUsername;
+  }
+
+  /**
+   * @name setNetwork
+   * @description Sets what network the API should use.
+   *
+   * @param network the network, supported values are: "mainnet" and "rinkeby"
+   */
+  setNetwork(network: string) {
+    Configuration.accessKeys.network = network;
   }
 
   /**
@@ -186,6 +197,10 @@ export class Configuration {
     if (sendParams) {
       request.data = data;
       request.params = params;
+    }
+
+    if (Configuration.accessKeys.network) {
+      request.header['Network'] = Configuration.accessKeys.network;
     }
 
     if (auth) {

--- a/src/lib/interfaces/configuration.ts
+++ b/src/lib/interfaces/configuration.ts
@@ -27,4 +27,5 @@ interface PillarSdkConfiguration {
   notificationsUrl?: string;
   investmentsUrl?: string;
   username?: string;
+  network?: string;
 }

--- a/src/tests/unit/asset.spec.ts
+++ b/src/tests/unit/asset.spec.ts
@@ -58,6 +58,23 @@ describe('Asset Class', () => {
       });
     });
 
+    it('should successfully call with valid data, Authorization and Network header', () => {
+      Configuration.setAuthTokens(accesToken, '');
+      pSdk.setNetwork('mainnet');
+      const assetDefaultsData = {
+        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
+      };
+
+      pSdk.asset.defaults(assetDefaultsData);
+
+      expect(requesterExecuteSpy).toHaveBeenCalledWith({
+        ...getConfiguration,
+        headers: { Authorization: 'Bearer myAccessToken', Network: 'mainnet' },
+        params: assetDefaultsData,
+        url: 'https://localhost:8080/asset/defaults',
+      });
+    });
+
     it('should throw an error if called with invalid data', async () => {
       const assetDefaultData = {
         walletId: null,
@@ -84,6 +101,23 @@ describe('Asset Class', () => {
       expect(requesterExecuteSpy).toHaveBeenCalledWith({
         ...getConfiguration,
         headers: { Authorization: 'Bearer myAccessToken' },
+        params: assetPreferredData,
+        url: 'https://localhost:8080/asset/preferred',
+      });
+    });
+
+    it('should successfully call with valid data, Authorization and Network header', () => {
+      Configuration.setAuthTokens(accesToken, '');
+      pSdk.setNetwork('mainnet');
+      const assetPreferredData = {
+        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
+      };
+
+      pSdk.asset.preferred(assetPreferredData);
+
+      expect(requesterExecuteSpy).toHaveBeenCalledWith({
+        ...getConfiguration,
+        headers: { Authorization: 'Bearer myAccessToken', Network: 'mainnet' },
         params: assetPreferredData,
         url: 'https://localhost:8080/asset/preferred',
       });
@@ -121,6 +155,24 @@ describe('Asset Class', () => {
       });
     });
 
+    it('should successfully call with valid data, Authorization and Network header', () => {
+      Configuration.setAuthTokens(accesToken, '');
+      pSdk.setNetwork('mainnet');
+      const assetSearchData = {
+        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
+        query: 'searchthis',
+      };
+
+      pSdk.asset.search(assetSearchData);
+
+      expect(requesterExecuteSpy).toHaveBeenCalledWith({
+        ...getConfiguration,
+        headers: { Authorization: 'Bearer myAccessToken', Network: 'mainnet' },
+        params: assetSearchData,
+        url: 'https://localhost:8080/asset/search',
+      });
+    });
+
     it('should throw an error if called with invalid data', async () => {
       const assetSearchData = {
         walletId: null,
@@ -150,6 +202,24 @@ describe('Asset Class', () => {
       expect(requesterExecuteSpy).toHaveBeenCalledWith({
         ...getConfiguration,
         headers: { Authorization: 'Bearer myAccessToken' },
+        params: assetListData,
+        url: 'https://localhost:8080/asset/list',
+      });
+    });
+
+    it('should successfully call with valid data, Authorization and Network header', () => {
+      Configuration.setAuthTokens(accesToken, '');
+      pSdk.setNetwork('mainnet');
+      const assetListData = {
+        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
+        symbols: ['SYM', 'BOL', 'LOG', 'NASE'],
+      };
+
+      pSdk.asset.list(assetListData);
+
+      expect(requesterExecuteSpy).toHaveBeenCalledWith({
+        ...getConfiguration,
+        headers: { Authorization: 'Bearer myAccessToken', Network: 'mainnet' },
         params: assetListData,
         url: 'https://localhost:8080/asset/list',
       });

--- a/src/tests/unit/asset.spec.ts
+++ b/src/tests/unit/asset.spec.ts
@@ -24,6 +24,8 @@ import { default as getConfiguration } from '../../utils/requester-configuration
 import { Requester } from '../../utils/requester';
 import { Configuration } from '../../lib/configuration';
 
+const defaultWalletId = '6e081b82-dbed-4485-bdbc-a808ad911758';
+
 describe('Asset Class', () => {
   let pSdk: PillarSdk;
 
@@ -44,9 +46,7 @@ describe('Asset Class', () => {
   describe('.defaults', () => {
     it('should successfully call with valid data and Authorization header', () => {
       Configuration.setAuthTokens(accesToken, '');
-      const assetDefaultsData = {
-        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-      };
+      const assetDefaultsData = { walletId: defaultWalletId };
 
       pSdk.asset.defaults(assetDefaultsData);
 
@@ -61,9 +61,7 @@ describe('Asset Class', () => {
     it('should successfully call with valid data, Authorization and Network header', () => {
       Configuration.setAuthTokens(accesToken, '');
       pSdk.setNetwork('mainnet');
-      const assetDefaultsData = {
-        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-      };
+      const assetDefaultsData = { walletId: defaultWalletId };
 
       pSdk.asset.defaults(assetDefaultsData);
 
@@ -92,9 +90,7 @@ describe('Asset Class', () => {
   describe('.preferred', () => {
     it('should successfully call with valid data and Authorization header', () => {
       Configuration.setAuthTokens(accesToken, '');
-      const assetPreferredData = {
-        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-      };
+      const assetPreferredData = { walletId: defaultWalletId };
 
       pSdk.asset.preferred(assetPreferredData);
 
@@ -109,9 +105,7 @@ describe('Asset Class', () => {
     it('should successfully call with valid data, Authorization and Network header', () => {
       Configuration.setAuthTokens(accesToken, '');
       pSdk.setNetwork('mainnet');
-      const assetPreferredData = {
-        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
-      };
+      const assetPreferredData = { walletId: defaultWalletId };
 
       pSdk.asset.preferred(assetPreferredData);
 
@@ -141,7 +135,7 @@ describe('Asset Class', () => {
     it('should successfully call with valid data and Authorization header', () => {
       Configuration.setAuthTokens(accesToken, '');
       const assetSearchData = {
-        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
+        walletId: defaultWalletId,
         query: 'searchthis',
       };
 
@@ -159,7 +153,7 @@ describe('Asset Class', () => {
       Configuration.setAuthTokens(accesToken, '');
       pSdk.setNetwork('mainnet');
       const assetSearchData = {
-        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
+        walletId: defaultWalletId,
         query: 'searchthis',
       };
 
@@ -193,7 +187,7 @@ describe('Asset Class', () => {
     it('should successfully call with valid data and Authorization header', () => {
       Configuration.setAuthTokens(accesToken, '');
       const assetListData = {
-        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
+        walletId: defaultWalletId,
         symbols: ['SYM', 'BOL', 'LOG', 'NASE'],
       };
 
@@ -211,7 +205,7 @@ describe('Asset Class', () => {
       Configuration.setAuthTokens(accesToken, '');
       pSdk.setNetwork('mainnet');
       const assetListData = {
-        walletId: '6e081b82-dbed-4485-bdbc-a808ad911758',
+        walletId: defaultWalletId,
         symbols: ['SYM', 'BOL', 'LOG', 'NASE'],
       };
 


### PR DESCRIPTION
Setting the Network header will make the API return assets information
scoped to a specific network.