### PR TITLE
add timeout param to default requester configs

### DIFF
--- a/src/utils/requester-configurations/delete.ts
+++ b/src/utils/requester-configurations/delete.ts
@@ -27,6 +27,7 @@ export default {
   headers: {},
   data: {},
   json: true,
+  timeout: 10000,
   httpsAgent: new https.Agent({
     rejectUnauthorized: false,
   }),

--- a/src/utils/requester-configurations/get.ts
+++ b/src/utils/requester-configurations/get.ts
@@ -26,6 +26,7 @@ export default {
   method: 'GET',
   headers: {},
   params: {},
+  timeout: 10000,
   httpsAgent: new https.Agent({
     rejectUnauthorized: false,
   }),

--- a/src/utils/requester-configurations/post.ts
+++ b/src/utils/requester-configurations/post.ts
@@ -27,6 +27,7 @@ export default {
   headers: {},
   data: {},
   json: true,
+  timeout: 10000,
   httpsAgent: new https.Agent({
     rejectUnauthorized: false,
   }),

--- a/src/utils/requester-configurations/put.ts
+++ b/src/utils/requester-configurations/put.ts
@@ -27,6 +27,7 @@ export default {
   headers: {},
   data: {},
   json: true,
+  timeout: 10000,
   httpsAgent: new https.Agent({
     rejectUnauthorized: false,
   }),


### PR DESCRIPTION
Per title. By default `axios` has no timeout set and if it happens then it is not rejected as exception, but is handled as resolved promise as `200` response with timeout error message.